### PR TITLE
Update provisioner for v2

### DIFF
--- a/csi-provisioner/Dockerfile
+++ b/csi-provisioner/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:1.13.5 AS build
 ENV GIT_UPSTREAM_REPO=https://github.com/kubernetes-csi/external-provisioner
 ENV GIT_FORK_REPO=https://github.com/storageos/external-provisioner
-ENV GIT_BRANCH=release-1.4-patched
+ENV GIT_BRANCH=53f0949-patched
 WORKDIR /go/src/github.com/storageos/images/external-provisioner
 COPY LICENSE .
 COPY csi-provisioner/build.sh /
@@ -21,7 +21,7 @@ FROM registry.access.redhat.com/ubi8/ubi-minimal
 LABEL name="csi-provisioner" \
     maintainer="support@storageos.com" \
     vendor="StorageOS" \
-    version="v1.4.0" \
+    version="53f0949-patched" \
     release="1" \
     distribution-scope="public" \
     architecture="x86_64" \


### PR DESCRIPTION
Uses upstream commit https://github.com/kubernetes-csi/external-provisioner/commit/53f0949f60eda07d2df3d4fbe37e95ff51ba7408

With patch: https://github.com/storageos/external-provisioner/commit/fd3540386579ecafea49a1188b2f6ebd6b2a4336