### PR TITLE
Bump kube-scheduler to v1.20

### DIFF
--- a/kube-scheduler/Dockerfile
+++ b/kube-scheduler/Dockerfile
@@ -1,8 +1,11 @@
-FROM golang:1.13.5 AS build
-ENV K8S_REPO_VERSION=v1.17.0
+FROM golang:1.15.11 AS build
+ENV K8S_REPO_VERSION=v1.20.0
 ENV K8S_COMPONENT_NAME=kube-scheduler
-WORKDIR /go/src/github.com/storageos/images/kube-scheduler
-COPY LICENSE .
+
+# WORKDIR is not getting created on RH build service, create it manually.
+RUN mkdir -p "$GOPATH/src/k8s.io/kubernetes"
+
+# Clone upstream and build from target tag directly. 
 RUN apt-get update && apt-get install rsync -y
 RUN git clone --branch $K8S_REPO_VERSION https://github.com/kubernetes/kubernetes $GOPATH/src/k8s.io/kubernetes --depth=1
 RUN cd "$GOPATH/src/k8s.io/kubernetes" && make WHAT=cmd/$K8S_COMPONENT_NAME GOFLAGS=-v
@@ -11,7 +14,7 @@ FROM registry.access.redhat.com/ubi8/ubi-minimal
 LABEL name="kube-scheduler" \
     maintainer="support@storageos.com" \
     vendor="StorageOS" \
-    version="v1.17.0" \
+    version="v1.20.0" \
     release="1" \
     distribution-scope="public" \
     architecture="x86_64" \
@@ -23,5 +26,5 @@ LABEL name="kube-scheduler" \
     description="This container is not intended to be run manually. Instead, use the StorageOS Cluster Operator to install and manage StorageOS."
 RUN mkdir -p /licenses
 COPY --from=build /go/src/k8s.io/kubernetes/_output/bin/kube-scheduler /usr/local/bin/kube-scheduler
-COPY --from=build /go/src/github.com/storageos/images/kube-scheduler/LICENSE /licenses/
+COPY --from=build /go/src/k8s.io/kubernetes/LICENSE /licenses/
 CMD ["/bin/sh", "-c"]


### PR DESCRIPTION
Bumps the kube-scheduler to v1.20, the default for Openshift v4.7.  This image is only used by Openshift/Red Hat Marketplace users.

I've had to build locally and push manually as the Red hat build service times out during the build.  It takes a while as the k8s repo is large and it runs the k8s codegen.  The image passed the scanner.